### PR TITLE
minor tweaks to gen_api_docs.py script, add sphinx.ext.autodoc in conf.py

### DIFF
--- a/docs/api/easybuild.framework.easyconfig.format.rst
+++ b/docs/api/easybuild.framework.easyconfig.format.rst
@@ -12,6 +12,7 @@ Submodules
    easybuild.framework.easyconfig.format.pyheaderconfigobj
    easybuild.framework.easyconfig.format.two
    easybuild.framework.easyconfig.format.version
+   easybuild.framework.easyconfig.format.yeb
 
 Module contents
 ---------------

--- a/docs/api/easybuild.framework.easyconfig.format.yeb.rst
+++ b/docs/api/easybuild.framework.easyconfig.format.yeb.rst
@@ -1,0 +1,7 @@
+easybuild.framework.easyconfig.format.yeb module
+================================================
+
+.. automodule:: easybuild.framework.easyconfig.format.yeb
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/easybuild.framework.easyconfig.rst
+++ b/docs/api/easybuild.framework.easyconfig.rst
@@ -21,6 +21,7 @@ Submodules
    easybuild.framework.easyconfig.templates
    easybuild.framework.easyconfig.tools
    easybuild.framework.easyconfig.tweak
+   easybuild.framework.easyconfig.types
 
 Module contents
 ---------------

--- a/docs/api/easybuild.framework.easyconfig.types.rst
+++ b/docs/api/easybuild.framework.easyconfig.types.rst
@@ -1,0 +1,7 @@
+easybuild.framework.easyconfig.types module
+===========================================
+
+.. automodule:: easybuild.framework.easyconfig.types
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/easybuild.toolchains.compiler.ibmxl.rst
+++ b/docs/api/easybuild.toolchains.compiler.ibmxl.rst
@@ -1,0 +1,7 @@
+easybuild.toolchains.compiler.ibmxl module
+==========================================
+
+.. automodule:: easybuild.toolchains.compiler.ibmxl
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/easybuild.toolchains.compiler.pgi.rst
+++ b/docs/api/easybuild.toolchains.compiler.pgi.rst
@@ -1,0 +1,7 @@
+easybuild.toolchains.compiler.pgi module
+========================================
+
+.. automodule:: easybuild.toolchains.compiler.pgi
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/easybuild.toolchains.compiler.rst
+++ b/docs/api/easybuild.toolchains.compiler.rst
@@ -11,7 +11,9 @@ Submodules
    easybuild.toolchains.compiler.cuda
    easybuild.toolchains.compiler.dummycompiler
    easybuild.toolchains.compiler.gcc
+   easybuild.toolchains.compiler.ibmxl
    easybuild.toolchains.compiler.inteliccifort
+   easybuild.toolchains.compiler.pgi
 
 Module contents
 ---------------

--- a/docs/api/easybuild.toolchains.craypgi.rst
+++ b/docs/api/easybuild.toolchains.craypgi.rst
@@ -1,0 +1,7 @@
+easybuild.toolchains.craypgi module
+===================================
+
+.. automodule:: easybuild.toolchains.craypgi
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/easybuild.toolchains.fft.rst
+++ b/docs/api/easybuild.toolchains.fft.rst
@@ -6,7 +6,6 @@ Submodules
 
 .. toctree::
 
-   easybuild.toolchains.fft.crayfftw
    easybuild.toolchains.fft.fftw
    easybuild.toolchains.fft.intelfftw
 

--- a/docs/api/easybuild.toolchains.gcccore.rst
+++ b/docs/api/easybuild.toolchains.gcccore.rst
@@ -1,0 +1,7 @@
+easybuild.toolchains.gcccore module
+===================================
+
+.. automodule:: easybuild.toolchains.gcccore
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/easybuild.toolchains.mpi.psmpi.rst
+++ b/docs/api/easybuild.toolchains.mpi.psmpi.rst
@@ -1,0 +1,7 @@
+easybuild.toolchains.mpi.psmpi module
+=====================================
+
+.. automodule:: easybuild.toolchains.mpi.psmpi
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/easybuild.toolchains.mpi.rst
+++ b/docs/api/easybuild.toolchains.mpi.rst
@@ -12,6 +12,7 @@ Submodules
    easybuild.toolchains.mpi.mpich2
    easybuild.toolchains.mpi.mvapich2
    easybuild.toolchains.mpi.openmpi
+   easybuild.toolchains.mpi.psmpi
    easybuild.toolchains.mpi.qlogicmpi
 
 Module contents

--- a/docs/api/easybuild.toolchains.pgi.rst
+++ b/docs/api/easybuild.toolchains.pgi.rst
@@ -1,0 +1,7 @@
+easybuild.toolchains.pgi module
+===============================
+
+.. automodule:: easybuild.toolchains.pgi
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/easybuild.toolchains.pomkl.rst
+++ b/docs/api/easybuild.toolchains.pomkl.rst
@@ -1,0 +1,7 @@
+easybuild.toolchains.pomkl module
+=================================
+
+.. automodule:: easybuild.toolchains.pomkl
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/easybuild.toolchains.pompi.rst
+++ b/docs/api/easybuild.toolchains.pompi.rst
@@ -1,0 +1,7 @@
+easybuild.toolchains.pompi module
+=================================
+
+.. automodule:: easybuild.toolchains.pompi
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/easybuild.toolchains.rst
+++ b/docs/api/easybuild.toolchains.rst
@@ -26,9 +26,11 @@ Submodules
    easybuild.toolchains.craycce
    easybuild.toolchains.craygnu
    easybuild.toolchains.crayintel
+   easybuild.toolchains.craypgi
    easybuild.toolchains.dummy
    easybuild.toolchains.foss
    easybuild.toolchains.gcc
+   easybuild.toolchains.gcccore
    easybuild.toolchains.gcccuda
    easybuild.toolchains.gimkl
    easybuild.toolchains.gimpi
@@ -60,6 +62,14 @@ Submodules
    easybuild.toolchains.ipsmpi
    easybuild.toolchains.iqacml
    easybuild.toolchains.ismkl
+   easybuild.toolchains.pgi
+   easybuild.toolchains.pomkl
+   easybuild.toolchains.pompi
+   easybuild.toolchains.xlcxlf
+   easybuild.toolchains.xlmpich
+   easybuild.toolchains.xlmpich2
+   easybuild.toolchains.xlmvapich2
+   easybuild.toolchains.xlompi
 
 Module contents
 ---------------

--- a/docs/api/easybuild.toolchains.xlcxlf.rst
+++ b/docs/api/easybuild.toolchains.xlcxlf.rst
@@ -1,0 +1,7 @@
+easybuild.toolchains.xlcxlf module
+==================================
+
+.. automodule:: easybuild.toolchains.xlcxlf
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/easybuild.toolchains.xlmpich.rst
+++ b/docs/api/easybuild.toolchains.xlmpich.rst
@@ -1,0 +1,7 @@
+easybuild.toolchains.xlmpich module
+===================================
+
+.. automodule:: easybuild.toolchains.xlmpich
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/easybuild.toolchains.xlmpich2.rst
+++ b/docs/api/easybuild.toolchains.xlmpich2.rst
@@ -1,0 +1,7 @@
+easybuild.toolchains.xlmpich2 module
+====================================
+
+.. automodule:: easybuild.toolchains.xlmpich2
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/easybuild.toolchains.xlmvapich2.rst
+++ b/docs/api/easybuild.toolchains.xlmvapich2.rst
@@ -1,0 +1,7 @@
+easybuild.toolchains.xlmvapich2 module
+======================================
+
+.. automodule:: easybuild.toolchains.xlmvapich2
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/easybuild.toolchains.xlompi.rst
+++ b/docs/api/easybuild.toolchains.xlompi.rst
@@ -1,0 +1,7 @@
+easybuild.toolchains.xlompi module
+==================================
+
+.. automodule:: easybuild.toolchains.xlompi
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/easybuild.tools.module_naming_scheme.categorized_mns.rst
+++ b/docs/api/easybuild.tools.module_naming_scheme.categorized_mns.rst
@@ -1,0 +1,7 @@
+easybuild.tools.module_naming_scheme.categorized_mns module
+===========================================================
+
+.. automodule:: easybuild.tools.module_naming_scheme.categorized_mns
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/easybuild.tools.module_naming_scheme.rst
+++ b/docs/api/easybuild.tools.module_naming_scheme.rst
@@ -7,6 +7,7 @@ Submodules
 .. toctree::
 
    easybuild.tools.module_naming_scheme.categorized_hmns
+   easybuild.tools.module_naming_scheme.categorized_mns
    easybuild.tools.module_naming_scheme.easybuild_mns
    easybuild.tools.module_naming_scheme.hierarchical_mns
    easybuild.tools.module_naming_scheme.migrate_from_eb_to_hmns

--- a/docs/api/easybuild.tools.multidiff.rst
+++ b/docs/api/easybuild.tools.multidiff.rst
@@ -1,0 +1,7 @@
+easybuild.tools.multidiff module
+================================
+
+.. automodule:: easybuild.tools.multidiff
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/easybuild.tools.repository.hgrepo.rst
+++ b/docs/api/easybuild.tools.repository.hgrepo.rst
@@ -1,0 +1,7 @@
+easybuild.tools.repository.hgrepo module
+========================================
+
+.. automodule:: easybuild.tools.repository.hgrepo
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/easybuild.tools.repository.rst
+++ b/docs/api/easybuild.tools.repository.rst
@@ -8,6 +8,7 @@ Submodules
 
    easybuild.tools.repository.filerepo
    easybuild.tools.repository.gitrepo
+   easybuild.tools.repository.hgrepo
    easybuild.tools.repository.repository
    easybuild.tools.repository.svnrepo
 

--- a/docs/api/easybuild.tools.rst
+++ b/docs/api/easybuild.tools.rst
@@ -32,6 +32,7 @@ Submodules
    easybuild.tools.jenkins
    easybuild.tools.module_generator
    easybuild.tools.modules
+   easybuild.tools.multidiff
    easybuild.tools.options
    easybuild.tools.ordereddict
    easybuild.tools.parallelbuild

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -22,7 +22,7 @@ import sys, os
 
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
-extensions = []
+extensions = ['sphinx.ext.autodoc']
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['.templates']

--- a/docs/scripts/gen_api_docs.py
+++ b/docs/scripts/gen_api_docs.py
@@ -1,5 +1,5 @@
 # #
-# Copyright 2015-2015 Ghent University
+# Copyright 2015-2016 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),
@@ -28,7 +28,7 @@ This script requires Sphinx to be installed (http://sphinx-doc.org/index.html).
 
 @author Caroline De Brouwer (Ghent University)
 """
-
+import os
 import subprocess
 
 from vsc.utils.generaloption import simple_option
@@ -36,13 +36,18 @@ from vsc.utils.generaloption import simple_option
 
 options = {
     'out_folder': ('Path to folder where api docfiles will be written', 'string', 'store', 'api', 'o'),
-    'module': ('Path to module for which api docs will be generated', 'string', 'store', 'easybuild', 'm')
+    'module': ('Path to module for which api docs will be generated', 'string', 'store', None, 'm')
 }
 so = simple_option(options)
+
+if so.options.module is None:
+    import easybuild
+    so.options.module = os.path.dirname(os.path.abspath(easybuild.__file__))
 
 # calls sphinx's automatic apidoc generator
 # -o specifies the output folder
 # -f forces to overwrite existing files
 # -e specifies that every module is written in a separate file
-subprocess.call("sphinx-apidoc -o" + so.options.out_folder + " " + so.options.module + " -f -e", shell=True)
-
+cmd = "sphinx-apidoc -o %s %s -f -e" % (so.options.out_folder, so.options.module)
+print "$ %s" % cmd
+subprocess.call(cmd, shell=True)


### PR DESCRIPTION
change in `conf.py` is required to correctly render API like in http://boegel-eb.readthedocs.io/en/api-docscript/api/easybuild.framework.easyblock.html

for https://github.com/hpcugent/easybuild/pull/139
